### PR TITLE
adding &#39; to preg_match_all function so link text does not get cut of...

### DIFF
--- a/modules/osci_tk_filters/osci_tk_filters.module
+++ b/modules/osci_tk_filters/osci_tk_filters.module
@@ -383,7 +383,7 @@ function _filter_cross_link($text, $filter, $format) {
  */
 function _process_cross_link($text) {
     if (empty($text[1])) return $text[0];
-    preg_match_all('/(\w+)=([\w\s\/.\-\"\/(\/)]*)/', $text[0], $matches);
+	preg_match_all('/(\w+)=([\w\s\/.\-\"\'\&#39;\/(\/)]*)/', $text[0], $matches);
     for ($i = 0; $i < count($matches[1]); $i++) {
         $args[$matches[1][$i]] = $matches[2][$i];
     }
@@ -393,7 +393,6 @@ function _process_cross_link($text) {
         $url .= "/p-{$args['paragraph']}";
     }
     $linkText = isset($args['text']) ? $args['text'] : "link";
-    
     $replace =  "<a href=\"{$url}\" class=\"cross-link\" target=\"_blank\" data-nid=\"{$nid}\">{$linkText}</a>";
     return $replace;
 }


### PR DESCRIPTION
...f at apostrophes
